### PR TITLE
Update docker image tag for api

### DIFF
--- a/api/todo-rest-service/overlays/production/kustomization.yaml
+++ b/api/todo-rest-service/overlays/production/kustomization.yaml
@@ -13,7 +13,7 @@ commonLabels:
   app: todo
 images:
 - name: 048246832408.dkr.ecr.ap-northeast-1.amazonaws.com/todo-rest-service
-  newTag: release.7bfeba162958bcce1e0078958abf666177e089f9
+  newTag: release.8fd4215b3ea11ef06ec03f4e0e619fb2475c9836
 configMapGenerator:
 - literals:
   - ALLOWED_ORIGIN=https://www.shakepiper.com


### PR DESCRIPTION
76ca47c<br>Update docker image tag for todo-rest-service to `release.8fd4215b3ea11ef06ec03f4e0e619fb2475c9836`