### PR TITLE
Update docker image tag for api

### DIFF
--- a/api/todo-rest-service/overlays/production/kustomization.yaml
+++ b/api/todo-rest-service/overlays/production/kustomization.yaml
@@ -13,7 +13,7 @@ commonLabels:
   app: todo
 images:
 - name: 048246832408.dkr.ecr.ap-northeast-1.amazonaws.com/todo-rest-service
-  newTag: release.af1d79750a66566dacf1dc238f98d54d4c1b8324
+  newTag: release.52f839c73b52d6fec01d3882f02f42662fcc0426
 configMapGenerator:
 - literals:
   - ALLOWED_ORIGIN=https://www.shakepiper.com


### PR DESCRIPTION
7a8caa1<br>Update docker image tag for todo-rest-service to `release.52f839c73b52d6fec01d3882f02f42662fcc0426`