### PR TITLE
Update docker image tag for api

### DIFF
--- a/api/todo-rest-service/overlays/production/kustomization.yaml
+++ b/api/todo-rest-service/overlays/production/kustomization.yaml
@@ -13,7 +13,7 @@ commonLabels:
   app: todo
 images:
 - name: 048246832408.dkr.ecr.ap-northeast-1.amazonaws.com/todo-rest-service
-  newTag: release.52f839c73b52d6fec01d3882f02f42662fcc0426
+  newTag: release.e7765c74146db305b960de6da856a52255aea56c
 configMapGenerator:
 - literals:
   - ALLOWED_ORIGIN=https://www.shakepiper.com


### PR DESCRIPTION
e4de779<br>Update docker image tag for todo-rest-service to `release.e7765c74146db305b960de6da856a52255aea56c`