### PR TITLE
Update docker image tag for api

### DIFF
--- a/api/todo-rest-service/overlays/production/kustomization.yaml
+++ b/api/todo-rest-service/overlays/production/kustomization.yaml
@@ -13,7 +13,7 @@ commonLabels:
   app: todo
 images:
 - name: 048246832408.dkr.ecr.ap-northeast-1.amazonaws.com/todo-rest-service
-  newTag: release.2796c41e8fb72238f7a20f7dd3d92336ffe1ae15
+  newTag: release.6e324edc72108bb369ae7dbbfe6cba8c31a087d2
 configMapGenerator:
 - literals:
   - ALLOWED_ORIGIN=https://www.shakepiper.com


### PR DESCRIPTION
5e398a4<br>Update docker image tag for todo-rest-service to `release.6e324edc72108bb369ae7dbbfe6cba8c31a087d2`