### PR TITLE
Update docker image tag for api

### DIFF
--- a/api/todo-rest-service/overlays/production/kustomization.yaml
+++ b/api/todo-rest-service/overlays/production/kustomization.yaml
@@ -13,7 +13,7 @@ commonLabels:
   app: todo
 images:
 - name: 048246832408.dkr.ecr.ap-northeast-1.amazonaws.com/todo-rest-service
-  newTag: release.6e324edc72108bb369ae7dbbfe6cba8c31a087d2
+  newTag: release.b1ab24893f6de4ece53f96de95fd530f7023d557
 configMapGenerator:
 - literals:
   - ALLOWED_ORIGIN=https://www.shakepiper.com


### PR DESCRIPTION
bc9e54d<br>Update docker image tag for todo-rest-service to `release.b1ab24893f6de4ece53f96de95fd530f7023d557`