### PR TITLE
Update docker image tag for api

### DIFF
--- a/api/todo-rest-service/overlays/production/kustomization.yaml
+++ b/api/todo-rest-service/overlays/production/kustomization.yaml
@@ -13,7 +13,7 @@ commonLabels:
   app: todo
 images:
 - name: 048246832408.dkr.ecr.ap-northeast-1.amazonaws.com/todo-rest-service
-  newTag: release.0b60cdf92670a700d9fb8e9d1b31663e09d478c0
+  newTag: release.49279938440a094a9dd6a2641dbb233508b00c4e
 configMapGenerator:
 - literals:
   - GO_ENV=prod


### PR DESCRIPTION
c460040<br>Update docker image tag for todo-rest-service to `release.49279938440a094a9dd6a2641dbb233508b00c4e`