### PR TITLE
Update docker image tag for todo api

### DIFF
--- a/api/todo-rest-service/overlays/production/kustomization.yaml
+++ b/api/todo-rest-service/overlays/production/kustomization.yaml
@@ -13,7 +13,7 @@ commonLabels:
   app: todo
 images:
 - name: 048246832408.dkr.ecr.ap-northeast-1.amazonaws.com/todo-rest-service
-  newTag: release.a4c5a54dbab3a3a096e0582a4ba692f2d8e4a4b9
+  newTag: release.1548e14fe7cfca06071272fc1355b85887ebb285
 configMapGenerator:
 - literals:
   - GO_ENV=prod


### PR DESCRIPTION
5fe9d18<br>Update docker image tag for todo-rest-service to `release.1548e14fe7cfca06071272fc1355b85887ebb285`